### PR TITLE
Refactorおよび単体テストの修正

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,6 +23,7 @@ llvm-*,
 -llvm-header-guard,
 misc-*,
 -misc-non-private-member-variables-in-classes,
+-misc-unused-parameters,
 modernize-*,
 -modernize-avoid-c-arrays,
 -modernize-loop-convert,
@@ -31,6 +32,7 @@ readability-*,
 -readability-braces-around-statements,
 -readability-convert-member-functions-to-static,
 -readability-function-cognitive-complexity,
+-readability-implicit-bool-conversion,
 performance-*,'
 WarningsAsErrors: ''
 HeaderFilterRegex: '(include|src|test)/.*\.hpp$'

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -13,7 +13,7 @@ env:
 jobs:
   unit_test:
     runs-on: ${{ inputs.os }}
-    timeout-minutes: 10
+    timeout-minutes: 5
 
     steps:
     - name: Clone Main Repository

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@
 
 # ignore build directories
 build
+
+# ignore log data for perf
+perf.data*

--- a/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
+++ b/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
@@ -23,10 +23,6 @@
 #include <bit>
 #include <cstddef>
 #include <cstdint>
-#include <thread>
-
-// external libraries
-#include "dbgroup/lock/common.hpp"
 
 // local sources
 #include "dbgroup/atomic/mwcas/utility.hpp"

--- a/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
+++ b/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
@@ -108,8 +108,8 @@ class alignas(kCacheLineSize) MwCASDescriptor
    */
   template <class T>
   static auto
-  Read(            //
-      void *addr,  // constを取り除いた． void * const addr ならいけるかも？
+  Read(  //
+      void *addr,
       const std::memory_order fence = std::memory_order_seq_cst)  //
       -> T
   {
@@ -117,10 +117,10 @@ class alignas(kCacheLineSize) MwCASDescriptor
 
     auto *target_addr = static_cast<std::atomic_uint64_t *>(addr);
     auto word = target_addr->load(fence);
-    while (true) {
-      if ((word & kMwCASFlag) == 0) return std::bit_cast<T>(word);
+    while (word & kMwCASFlag) {
       FollowIfNeeded(target_addr, word, fence);
     }
+    return std::bit_cast<T>(word);
   }
 
   /**
@@ -208,6 +208,17 @@ class alignas(kCacheLineSize) MwCASDescriptor
       std::memory_order fence);
 
   /**
+   * @brief An actual MwCAS procedure.
+   *
+   * @param begin_pos The begin position of target words.
+   * @retval true if a MwCAS operation succeeds.
+   * @retval false otherwise.
+   */
+  auto MwCASInternal(        //
+      size_t begin_pos = 0)  //
+      -> bool;
+
+  /**
    * @brief Swap an embedded descriptor into a desired value.
    *
    * @param desc_addr The address of this descriptor with the flag.
@@ -222,21 +233,6 @@ class alignas(kCacheLineSize) MwCASDescriptor
       -> uint32_t;
 
   /*############################################################################
-   * Internal utility functions
-   *##########################################################################*/
-
-  /**
-   * @brief An actual MwCAS procedure.
-   *
-   * @param begin_pos The begin position of target words.
-   * @retval true if a MwCAS operation succeeds.
-   * @retval false otherwise.
-   */
-  auto MwCASInternal(        //
-      size_t begin_pos = 0)  //
-      -> bool;
-
-  /*############################################################################
    * Internal member variables
    *##########################################################################*/
 
@@ -244,7 +240,7 @@ class alignas(kCacheLineSize) MwCASDescriptor
   std::atomic<Status> stat_{kUndecided};
 
   /// @brief The total number of threads that have completed referencing.
-  std::atomic_uint32_t exit_cnt_;
+  std::atomic_uint32_t exit_cnt_{};
 
   /// @brief Target entries of MwCAS.
   std::array<MwCASTarget, kMwCASCapacity> targets_ = {};

--- a/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
+++ b/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
@@ -97,27 +97,6 @@ class alignas(kCacheLineSize) MwCASDescriptor
    *##########################################################################*/
 
   /**
-   * @brief A class for representing MwCAS targets.
-   *
-   */
-  struct MwCASTarget {
-    /// @brief A target memory address.
-    std::atomic_uint64_t *addr;
-
-    /// @brief An expected value of a target field.
-    uint64_t old_val;
-
-    /// @brief An inserting value into a target field.
-    uint64_t new_val;
-
-    /// @brief The number of followers that start from this address.
-    std::atomic_uint32_t cnt;
-
-    /// @brief A fence to be inserted when embedding a new value.
-    std::memory_order fence;
-  };
-
-  /**
    * @brief Read a value from a given memory address.
    *
    * @tparam T An expected class of a target field.
@@ -168,20 +147,6 @@ class alignas(kCacheLineSize) MwCASDescriptor
   }
 
   /**
-   * @brief Swap an embedded descriptor into a desired value.
-   *
-   * @param desc_addr The address of this descriptor with the flag.
-   * @param target A target MwCAS information.
-   * @param desired A desired value to be embedded.
-   * @return The number of followers.
-   */
-  auto Finalize(            //
-      uint64_t desc_addr,   //
-      MwCASTarget &target,  //
-      uint64_t desired)     //
-      -> uint32_t;
-
-  /**
    * @brief Perform a MwCAS operation by using registered targets.
    *
    * @retval true if a MwCAS operation succeeds.
@@ -189,12 +154,6 @@ class alignas(kCacheLineSize) MwCASDescriptor
    */
   auto MwCAS()  //
       -> bool;
-
-  /*############################################################################
-   * Internal constants
-   *##########################################################################*/
-  /// @brief A bitmask with only the "descriptor address" portion set to 1.
-  static constexpr uint64_t kAddrMask = (1UL << 47) - 1;
 
  private:
   /*############################################################################
@@ -211,9 +170,42 @@ class alignas(kCacheLineSize) MwCASDescriptor
     kFailed,
   };
 
+  /**
+   * @brief A class for representing MwCAS targets.
+   *
+   */
+  struct MwCASTarget {
+    /// @brief A target memory address.
+    std::atomic_uint64_t *addr;
+
+    /// @brief An expected value of a target field.
+    uint64_t old_val;
+
+    /// @brief An inserting value into a target field.
+    uint64_t new_val;
+
+    /// @brief The number of followers that start from this address.
+    std::atomic_uint32_t cnt;
+
+    /// @brief A fence to be inserted when embedding a new value.
+    std::memory_order fence;
+  };
+
   /*############################################################################
    * Internal APIs
    *##########################################################################*/
+
+  /**
+   * @brief Insert back-off and follow the existing MwCAS if needed.
+   *
+   * @param[in] addr A target address.
+   * @param[in,out] word The current value of a target address.
+   * @param[in] fence A memory fence.
+   */
+  static void FollowIfNeeded(  //
+      std::atomic_uint64_t *addr,
+      uint64_t &word,
+      std::memory_order fence);
 
   /**
    * @brief Embed a descriptor into this target address to linearlize MwCAS.
@@ -229,16 +221,18 @@ class alignas(kCacheLineSize) MwCASDescriptor
       -> bool;
 
   /**
-   * @brief Insert back-off and follow the existing MwCAS if needed.
+   * @brief Swap an embedded descriptor into a desired value.
    *
-   * @param[in] addr A target address.
-   * @param[in,out] word The current value of a target address.
-   * @param[in] fence A memory fence.
+   * @param desc_addr The address of this descriptor with the flag.
+   * @param target A target MwCAS information.
+   * @param desired A desired value to be embedded.
+   * @return The number of followers.
    */
-  static void FollowIfNeeded(  //
-      std::atomic_uint64_t *addr,
-      uint64_t &word,
-      std::memory_order fence);
+  auto Finalize(            //
+      uint64_t desc_addr,   //
+      MwCASTarget &target,  //
+      uint64_t desired)     //
+      -> uint32_t;
 
   /*############################################################################
    * Internal utility functions

--- a/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
+++ b/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
@@ -208,19 +208,6 @@ class alignas(kCacheLineSize) MwCASDescriptor
       std::memory_order fence);
 
   /**
-   * @brief Embed a descriptor into this target address to linearlize MwCAS.
-   *
-   * @param desc_addr The address of this descriptor with a MwCAS flag.
-   * @param pos The position of a target word.
-   * @retval true if the descriptor address is successfully embedded.
-   * @retval false otherwise.
-   */
-  auto EmbedDescriptor(  //
-      uint64_t desc_addr,
-      size_t pos)  //
-      -> bool;
-
-  /**
    * @brief Swap an embedded descriptor into a desired value.
    *
    * @param desc_addr The address of this descriptor with the flag.

--- a/src/lock_free/mwcas_descriptor.cpp
+++ b/src/lock_free/mwcas_descriptor.cpp
@@ -135,8 +135,8 @@ MwCASDescriptor::FollowIfNeeded(  //
 
 auto
 MwCASDescriptor::MwCASInternal(  //
-    const size_t begin_pos       //
-    ) -> bool
+    const size_t begin_pos)      //
+    -> bool
 {
   const auto desc_addr = std::bit_cast<uint64_t>(this) | kMwCASFlag;
   auto cur_stat = stat_.load(kSeqCst);
@@ -147,16 +147,16 @@ MwCASDescriptor::MwCASInternal(  //
       auto *addr = target.addr;
       auto word = addr->load(kSeqCst);
       while (true) {
-        if (word & kMwCASFlag) {
-          if (((word ^ desc_addr) & kDescMask) == 0) break;
-          FollowIfNeeded(addr, word, kSeqCst);
-          continue;
+        if (word == target.old_val
+                && addr->compare_exchange_strong(word, desc_addr, kSeqCst, kSeqCst)
+            || (((word ^ desc_addr) & kDescMask) == 0)) {
+          break;
         }
-        if (word != target.old_val) {
+        if ((word & kMwCASFlag) == 0) {
           stat = kFailed;
           goto out;
         }
-        if (addr->compare_exchange_strong(word, desc_addr, kSeqCst, kSeqCst)) break;
+        FollowIfNeeded(addr, word, kSeqCst);
       }
     }
   out:

--- a/src/lock_free/mwcas_descriptor.cpp
+++ b/src/lock_free/mwcas_descriptor.cpp
@@ -64,13 +64,14 @@ constexpr uint64_t kDescMask = kMwCASFlag | kAddrMask;
 /*##############################################################################
  * Local global variable
  *############################################################################*/
+
 /// @brief A thread local descriptor for reuse.
 thread_local std::unique_ptr<MwCASDescriptor> _tls = nullptr;  // NOLINT
 
 }  // namespace
 
 /*##############################################################################
- * Static utilities
+ * Public APIs
  *############################################################################*/
 
 auto
@@ -86,9 +87,6 @@ MwCASDescriptor::GetDescriptor()  //
   return desc;
 }
 
-/*##############################################################################
- * Utilities
- *############################################################################*/
 auto
 MwCASDescriptor::MwCAS()  //
     -> bool
@@ -96,6 +94,39 @@ MwCASDescriptor::MwCAS()  //
   // set a memory fence
   stat_.store(kUndecided, kRelease);
   return MwCASInternal();
+}
+
+/*##############################################################################
+ * Internal APIs
+ *############################################################################*/
+
+void
+MwCASDescriptor::FollowIfNeeded(  //
+    std::atomic_uint64_t *addr,
+    uint64_t &word,
+    const std::memory_order fence)
+{
+  const auto another_word = word;
+  std::this_thread::sleep_for(kBackOffTime);
+  word = addr->load(fence);
+  if (word != another_word) return;  // other threads modified this field
+
+  // a long CPU stall has been detected, so perform another MwCAS
+  const auto incremented = word + kCntUnit;
+  if (addr->compare_exchange_strong(word, incremented, kSeqCst, kSeqCst)) {
+    // follow another MwCAS
+    auto *another_desc = std::bit_cast<MwCASDescriptor *>(word & kAddrMask);
+    const auto pos = (word & kPosMask) >> kPosShift;
+    auto &desc_cnt = another_desc->targets_[pos].cnt;
+    auto cur_cnt = desc_cnt.load(kSeqCst);
+    const auto cnt = static_cast<uint32_t>((incremented & kCntMask) >> kCntShift);
+    while (cur_cnt < cnt) {  // increment the descriptor's counter
+      if (desc_cnt.compare_exchange_weak(cur_cnt, cnt, kSeqCst, kSeqCst)) break;
+      CPP_UTILITY_SPINLOCK_HINT
+    }
+    another_desc->MwCASInternal(pos + 1);
+    word = addr->load(kSeqCst);
+  }
 }
 
 auto
@@ -152,40 +183,11 @@ MwCASDescriptor::MwCASInternal(  //
   return succeeded;
 }
 
-void
-MwCASDescriptor::FollowIfNeeded(  //
-    std::atomic_uint64_t *addr,
-    uint64_t &word,
-    const std::memory_order fence)
-{
-  const auto another_word = word;
-  std::this_thread::sleep_for(kBackOffTime);
-  word = addr->load(fence);
-  if (word != another_word) return;  // other threads modified this field
-
-  // a long CPU stall has been detected, so perform another MwCAS
-  const auto incremented = word + kCntUnit;
-  if (addr->compare_exchange_strong(word, incremented, kSeqCst, kSeqCst)) {
-    // follow another MwCAS
-    auto *another_desc = std::bit_cast<MwCASDescriptor *>(word & kAddrMask);
-    const auto pos = (word & kPosMask) >> kPosShift;
-    auto &desc_cnt = another_desc->targets_[pos].cnt;
-    auto cur_cnt = desc_cnt.load(kSeqCst);
-    const auto cnt = static_cast<uint32_t>((incremented & kCntMask) >> kCntShift);
-    while (cur_cnt < cnt) {  // increment the descriptor's counter
-      if (desc_cnt.compare_exchange_weak(cur_cnt, cnt, kSeqCst, kSeqCst)) break;
-      CPP_UTILITY_SPINLOCK_HINT
-    }
-    another_desc->MwCASInternal(pos + 1);
-    word = addr->load(kSeqCst);
-  }
-}
-
 auto
-MwCASDescriptor::Finalize(     // 依存関係が微妙
-    const uint64_t desc_addr,  //
-    MwCASTarget &target,       //
-    const uint64_t desired)    //
+MwCASDescriptor::Finalize(  //
+    const uint64_t desc_addr,
+    MwCASTarget &target,
+    const uint64_t desired)  //
     -> uint32_t
 {
   while (true) {

--- a/src/lock_free/mwcas_descriptor.cpp
+++ b/src/lock_free/mwcas_descriptor.cpp
@@ -19,7 +19,11 @@
 
 // C++ standard libraries
 #include <atomic>
+#include <bit>
 #include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <thread>
 
 // external libraries
 #include "dbgroup/lock/common.hpp"

--- a/src/lock_free/mwcas_descriptor.cpp
+++ b/src/lock_free/mwcas_descriptor.cpp
@@ -50,13 +50,13 @@ constexpr uint64_t kCntShift = 50;
 constexpr uint64_t kCntUnit = 1UL << kCntShift;
 
 /// @brief A bitmask with only the "descriptor address" portion set to 1.
-constexpr uint64_t kAddrMask = (1UL << 47) - 1;
+constexpr uint64_t kAddrMask = (1UL << 47UL) - 1UL;
 
 /// @brief A bitmask with only the "begin position" portion set to 1.
-constexpr uint64_t kPosMask = (((1UL << (1 + kCntShift - kPosShift)) - 1) << kPosShift);
+constexpr uint64_t kPosMask = (((1UL << (1UL + kCntShift - kPosShift)) - 1UL) << kPosShift);
 
 /// @brief A bitmask with only the "reference counter" portion set to 1.
-constexpr uint64_t kCntMask = (((1UL << (64 - kCntShift)) - 1) << kCntShift);
+constexpr uint64_t kCntMask = (((1UL << (64UL - kCntShift)) - 1UL) << kCntShift);
 
 /// @brief A bitmask with only the "MwCAS FLAG" and "descriptor address" portions set to 1.
 constexpr uint64_t kDescMask = kMwCASFlag | kAddrMask;

--- a/src/lock_free/mwcas_descriptor.cpp
+++ b/src/lock_free/mwcas_descriptor.cpp
@@ -49,6 +49,9 @@ constexpr uint64_t kCntShift = 50;
 /// @brief A constant for incrementing the "reference counter".
 constexpr uint64_t kCntUnit = 1UL << kCntShift;
 
+/// @brief A bitmask with only the "descriptor address" portion set to 1.
+constexpr uint64_t kAddrMask = (1UL << 47) - 1;
+
 /// @brief A bitmask with only the "begin position" portion set to 1.
 constexpr uint64_t kPosMask = (((1UL << (1 + kCntShift - kPosShift)) - 1) << kPosShift);
 
@@ -56,7 +59,7 @@ constexpr uint64_t kPosMask = (((1UL << (1 + kCntShift - kPosShift)) - 1) << kPo
 constexpr uint64_t kCntMask = (((1UL << (64 - kCntShift)) - 1) << kCntShift);
 
 /// @brief A bitmask with only the "MwCAS FLAG" and "descriptor address" portions set to 1.
-constexpr uint64_t kDescMask = kMwCASFlag | MwCASDescriptor::kAddrMask;
+constexpr uint64_t kDescMask = kMwCASFlag | kAddrMask;
 
 /*##############################################################################
  * Local global variable
@@ -137,6 +140,35 @@ MwCASDescriptor::MwCASInternal(  //
   return succeeded;
 }
 
+void
+MwCASDescriptor::FollowIfNeeded(  //
+    std::atomic_uint64_t *addr,
+    uint64_t &word,
+    const std::memory_order fence)
+{
+  const auto another_word = word;
+  std::this_thread::sleep_for(kBackOffTime);
+  word = addr->load(fence);
+  if (word != another_word) return;  // other threads modified this field
+
+  // a long CPU stall has been detected, so perform another MwCAS
+  const auto incremented = word + kCntUnit;
+  if (addr->compare_exchange_strong(word, incremented, kSeqCst, kSeqCst)) {
+    // follow another MwCAS
+    auto *another_desc = std::bit_cast<MwCASDescriptor *>(word & kAddrMask);
+    const auto pos = (word & kPosMask) >> kPosShift;
+    auto &desc_cnt = another_desc->targets_[pos].cnt;
+    auto cur_cnt = desc_cnt.load(kSeqCst);
+    const auto cnt = static_cast<uint32_t>((incremented & kCntMask) >> kCntShift);
+    while (cur_cnt < cnt) {  // increment the descriptor's counter
+      if (desc_cnt.compare_exchange_weak(cur_cnt, cnt, kSeqCst, kSeqCst)) break;
+      CPP_UTILITY_SPINLOCK_HINT
+    }
+    another_desc->MwCASInternal(pos + 1);
+    word = addr->load(kSeqCst);
+  }
+}
+
 auto
 MwCASDescriptor::EmbedDescriptor(  //
     const uint64_t desc_addr,
@@ -199,35 +231,6 @@ MwCASDescriptor::Finalize(     // 依存関係が微妙
       if (target.cnt.compare_exchange_weak(cur_cnt, cnt, kSeqCst, kSeqCst)) break;
       CPP_UTILITY_SPINLOCK_HINT
     }
-  }
-}
-
-void
-MwCASDescriptor::FollowIfNeeded(  //
-    std::atomic_uint64_t *addr,
-    uint64_t &word,
-    const std::memory_order fence)
-{
-  const auto another_word = word;
-  std::this_thread::sleep_for(kBackOffTime);
-  word = addr->load(fence);
-  if (word != another_word) return;  // other threads modified this field
-
-  // a long CPU stall has been detected, so perform another MwCAS
-  const auto incremented = word + kCntUnit;
-  if (addr->compare_exchange_strong(word, incremented, kSeqCst, kSeqCst)) {
-    // follow another MwCAS
-    auto *another_desc = std::bit_cast<MwCASDescriptor *>(word & kAddrMask);
-    const auto pos = (word & kPosMask) >> kPosShift;
-    auto &desc_cnt = another_desc->targets_[pos].cnt;
-    auto cur_cnt = desc_cnt.load(kSeqCst);
-    const auto cnt = static_cast<uint32_t>((incremented & kCntMask) >> kCntShift);
-    while (cur_cnt < cnt) {  // increment the descriptor's counter
-      if (desc_cnt.compare_exchange_weak(cur_cnt, cnt, kSeqCst, kSeqCst)) break;
-      CPP_UTILITY_SPINLOCK_HINT
-    }
-    another_desc->MwCASInternal(pos + 1);
-    word = addr->load(kSeqCst);
   }
 }
 

--- a/src/lock_free/mwcas_descriptor.cpp
+++ b/src/lock_free/mwcas_descriptor.cpp
@@ -57,10 +57,10 @@ constexpr uint64_t kCntUnit = 1UL << kCntShift;
 constexpr uint64_t kAddrMask = (1UL << 47UL) - 1UL;
 
 /// @brief A bitmask with only the "begin position" portion set to 1.
-constexpr uint64_t kPosMask = (((1UL << (1UL + kCntShift - kPosShift)) - 1UL) << kPosShift);
+constexpr uint64_t kPosMask = (0b111UL << kPosShift);
 
 /// @brief A bitmask with only the "reference counter" portion set to 1.
-constexpr uint64_t kCntMask = (((1UL << (64UL - kCntShift)) - 1UL) << kCntShift);
+constexpr uint64_t kCntMask = (0b11111'11111111UL << kCntShift);
 
 /// @brief A bitmask with only the "MwCAS FLAG" and "descriptor address" portions set to 1.
 constexpr uint64_t kDescMask = kMwCASFlag | kAddrMask;

--- a/src/lock_free/mwcas_descriptor.cpp
+++ b/src/lock_free/mwcas_descriptor.cpp
@@ -108,11 +108,23 @@ MwCASDescriptor::MwCASInternal(  //
   if (cur_stat == kUndecided) {
     auto stat = kSucceeded;
     for (size_t i = begin_pos; i < target_cnt_; ++i) {
-      if (!EmbedDescriptor(desc_addr, i)) {
-        stat = kFailed;
-        break;
+      auto &target = targets_[i];
+      auto *addr = target.addr;
+      auto word = addr->load(kSeqCst);
+      while (true) {
+        if (word & kMwCASFlag) {
+          if (((word ^ desc_addr) & kDescMask) == 0) break;
+          FollowIfNeeded(addr, word, kSeqCst);
+          continue;
+        }
+        if (word != target.old_val) {
+          stat = kFailed;
+          goto out;
+        }
+        if (addr->compare_exchange_strong(word, desc_addr, kSeqCst, kSeqCst)) break;
       }
     }
+  out:
     cur_stat = stat_.load(kSeqCst);
     if (cur_stat == kUndecided && stat_.compare_exchange_strong(cur_stat, stat, kSeqCst, kSeqCst)) {
       cur_stat = stat;
@@ -166,46 +178,6 @@ MwCASDescriptor::FollowIfNeeded(  //
     }
     another_desc->MwCASInternal(pos + 1);
     word = addr->load(kSeqCst);
-  }
-}
-
-auto
-MwCASDescriptor::EmbedDescriptor(  //
-    const uint64_t desc_addr,
-    const size_t pos)  //
-    -> bool
-{
-  auto &target = targets_[pos];
-  auto *addr = target.addr;
-  auto word = addr->load(kSeqCst);
-  while (true) {
-    while (word & kMwCASFlag) {
-      if (((word ^ desc_addr) & kDescMask) == 0) return true;
-      const auto another_word = word;
-      std::this_thread::sleep_for(kBackOffTime);
-      word = addr->load(kSeqCst);
-      if (word != another_word) continue;  // other threads modified this field
-
-      // a long CPU stall has been detected, so perform another MwCAS
-      const auto incremented = word + kCntUnit;
-      if (addr->compare_exchange_strong(word, incremented, kSeqCst, kSeqCst)) {
-        // follow another MwCAS
-        auto *another_desc = std::bit_cast<MwCASDescriptor *>(word & kAddrMask);
-        const auto pos = (word & kPosMask) >> kPosShift;
-        auto &desc_cnt = another_desc->targets_[pos].cnt;
-        auto cur_cnt = desc_cnt.load(kSeqCst);
-        const auto cnt = static_cast<uint32_t>((incremented & kCntMask) >> kCntShift);
-        while (cur_cnt < cnt) {  // increment the descriptor's counter
-          if (desc_cnt.compare_exchange_weak(cur_cnt, cnt, kSeqCst, kSeqCst)) break;
-          CPP_UTILITY_SPINLOCK_HINT
-        }
-        another_desc->MwCASInternal(pos + 1);
-        word = addr->load(kSeqCst);
-      }
-    }
-
-    if (word != target.old_val) return false;
-    if (addr->compare_exchange_strong(word, desc_addr, kSeqCst, kSeqCst)) return true;
   }
 }
 

--- a/test/mwcas_descriptors_test.cpp
+++ b/test/mwcas_descriptors_test.cpp
@@ -235,7 +235,7 @@ class MwCASDescriptorFixture : public ::testing::Test
 
   Target target_fields_[kTargetFieldNum]{};
 
-  std::uniform_int_distribution<size_t> id_dist_{0, kMwCASCapacity - 1};
+  std::uniform_int_distribution<size_t> id_dist_{0, kTargetFieldNum - 1};
 
   std::shared_mutex main_lock_{};
 


### PR DESCRIPTION
最終確認も兼ねて手元で修正したり [Linterによる警告への対応](https://github.com/dbgroup-nagoya-u/mwcas/commit/eb8238c3df1f0c7d5a95b70c610e3772185ed743) をしたりしました。詳細はコミットログを見てほしいですが、主な変更内容としては以下のとおりです。

- [関数のvisibilityの修正](https://github.com/dbgroup-nagoya-u/mwcas/commit/8dc012fbf2059938c2711c119296a56f8e9d0507)
- [EmbedDiscriptorを削除しMwCASInternalに統合](https://github.com/dbgroup-nagoya-u/mwcas/commit/448815352fd835a28884b1bcc3e6ffadefab7e2b)
- [Cnt用のビットマスクが誤っていたのを修正](https://github.com/dbgroup-nagoya-u/mwcas/commit/17a48e6bce261fdc2144f71b7719e9c718df203c)
    - `MwCASFlag` のビットまで含まれていました。
- [性能改善のために、先に埋込み処理を試行する（記述子かどうかの確認のための分岐予測を避ける）よう修正](https://github.com/dbgroup-nagoya-u/mwcas/commit/f3bc57e0a1bbfb5249c65f837fdf9722565dc82d)

で、先ほどSlackで話したとおり [単体テストを修正](https://github.com/dbgroup-nagoya-u/mwcas/commit/835dcecf5477f8b0f48f1fe5f63b9e4a29ea9b89) するとABA問題によって無限ループに入ります。交換が終わった領域に対して再度同じ記述子が埋め込まれることでカウンタが誤った値になり、 `Finalize` 処理が完了しません。RDCSSを使わないという今回の手続き上[^1]、誤った記述子を埋め込む可能性があるのは避けられません。そのため、自身が二度目の実行であることをなんとか認識し、undo処理を実行してあげる必要があります。

---

以下、PRでもらったコメントへの回答です。

> 1. FollowIfNeededをstatic関数として定義した．

これはOKです． `static` メンバ関数とするか，つまりクラス関数とするかはインスタンスのメンバ変数にアクセスするかに依存します． `FinalizeIfNeeded` 関数の処理に必要な情報は全て引数に入っているため，インスタンスへの依存を消せます．

言い換えると， `static` でない関数内でメンバ関数を呼ぶ際は，常に `this->Function` というように `this` ポインタを経由して呼び出していることになります．

> 2. Read関数で*target_addrを定数でなくした．理由はFollowIfNeeded関数でCASが使えなくなってしまうため．また，同様の理由でRead関数の引数void const *addrもvoid *addrにした．

これもOKです．デッドロックフリーの場合は値を変更しないことが保証されているため `const` 修飾子をつけますが，ロックフリーverでは追従処理によって値を変更する可能性があるため `const` はつけられません．

なお， `const` 修飾子はあくまで **変更しないという意思** を宣言するだけで， **コンパイラは最適化時にその有無を一切考慮しない** 点には注意が必要です．そのため，C++には特殊なキャストとして `const_cast` があり，これを使えば `const` 修飾子を自由につけたり外したりできます．なので，「実際には値を変更しないため `const` 修飾子をつけたいけれど，中で使用するメンバ関数が `const` でない」ときに一時的に `const` を外すみたいな離れ業もやろうと思えばできます．

> 3. Finalize関数の引数としてMwCASTarget型が必要だが，定義する順番が合わなかったのでMwCASTargetの定義位置を移動した．その結果MwCASTargetがprivateからpublicになった．

これはよくないですね． `public` ，つまり公開APIにするかどうかはユーザにそのAPIを見せるかどうかで決めるべきで，コンパイル時の依存関係から決めるべきではありません．今回で言えばそもそも `Finalize` はクラス内でしか使用しないので， `Finalize` を `private` に移す方が適切です．

なお，型を `public` に移す場合も，宣言の順番に気をつけましょう．書く人が各々好きな箇所で型や関数を宣言すると読む際に大変なので，基本的に組織や開発グループでコーディング規約が定められています．石川研では基本的に [GoogleのC++コーディング規約](https://ttsuki.github.io/styleguide/cppguide.ja.html) に従うようにしているので，書く際はそれを意識してみてください．

[^1]: 厳密には、RDCSSを使っても誤った記述子自体は埋め込まれる気がしています。ただ、その後のundo処理自体は正しく行われるのでセーフなのだと思います（本当にセーフなのかちょっと疑ってますが）。