### PR TITLE
バージョン埋込みの修正

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -161,6 +161,8 @@
     "concepts": "cpp",
     "numbers": "cpp",
     "semaphore": "cpp",
-    "stop_token": "cpp"
+    "stop_token": "cpp",
+    "regex": "cpp",
+    "ranges": "cpp"
   },
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,12 @@ if(NOT TARGET dbgroup::${PROJECT_NAME})
   )
 
   set(
+    MWCAS_VALUE_BIT_NUM
+    "48" CACHE STRING
+    "The maximum number of bits for representing values."
+  )
+
+  set(
     MWCAS_RETRY_THRESHOLD
     "10" CACHE STRING
     "The maximum number of retries for preventing busy loops."
@@ -78,6 +84,7 @@ if(NOT TARGET dbgroup::${PROJECT_NAME})
   )
   target_compile_definitions(${PROJECT_NAME} PUBLIC
     MWCAS_CAPACITY=${MWCAS_CAPACITY}
+    MWCAS_VALUE_BIT_NUM=${MWCAS_VALUE_BIT_NUM}
     MWCAS_RETRY_THRESHOLD=${MWCAS_RETRY_THRESHOLD}
     MWCAS_BACKOFF_TIME=${MWCAS_BACKOFF_TIME}
     $<$<BOOL:${MWCAS_HAS_SPINLOCK_HINT}>:MWCAS_HAS_SPINLOCK_HINT>

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ cd mwcas
 
 - `MWCAS_CAPACITY`: The maximum number of target words of MwCAS (default: `4`).
     - In order to maximize performance, it is desirable to specify the minimum number needed. Otherwise, the extra space will pollute the CPU cache.
+- `MWCAS_VALUE_BIT_NUM`: The maximum number of bits for representing values (default: `48`).
 - `MWCAS_RETRY_THRESHOLD`: The maximum number of retries for preventing busy loops. (default: `10`).
 - `MWCAS_BACKOFF_TIME`: A back-off time for preventing busy loops [us]. (default: `10`).
 

--- a/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
+++ b/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
@@ -116,7 +116,7 @@ class alignas(kCacheLineSize) MwCASDescriptor
     while (word & kMwCASFlag) {
       FollowIfNeeded(target_addr, word, fence);
     }
-    return std::bit_cast<T>(word);
+    return std::bit_cast<T>(word & kValueMask);
   }
 
   /**
@@ -186,6 +186,25 @@ class alignas(kCacheLineSize) MwCASDescriptor
     /// @brief A fence to be inserted when embedding a new value.
     std::memory_order fence;
   };
+
+  /*############################################################################
+   * Internal constants
+   *##########################################################################*/
+
+  /// @brief The begin bit position of versions.
+  static constexpr uint64_t kVersionShift = kValueBitNum;
+
+  /// @brief A unit value for incrementing versions.
+  static constexpr uint64_t kVersionUnit = 1UL << kVersionShift;
+
+  /// @brief A bit mask for extracting actual values.
+  static constexpr uint64_t kValueMask = kVersionUnit - 1UL;
+
+  /// @brief A bit mask for extracting versions and actual values.
+  static constexpr uint64_t kVerAndValMask = ~kMwCASFlag;
+
+  /// @brief A bit mask for extracting versions.
+  static constexpr uint64_t kVersionMask = kVerAndValMask ^ kValueMask;
 
   /*############################################################################
    * Internal APIs

--- a/include/dbgroup/atomic/mwcas/utility.hpp
+++ b/include/dbgroup/atomic/mwcas/utility.hpp
@@ -52,6 +52,9 @@ constexpr size_t kCacheLineSize = 64;
 /// @brief The maximum number of target words of MwCAS.
 constexpr size_t kMwCASCapacity = (MWCAS_CAPACITY);
 
+/// @brief The maximum number of bits for representing values.
+constexpr size_t kValueBitNum = (MWCAS_VALUE_BIT_NUM);
+
 /// @brief The maximum number of retries for preventing busy loops.
 constexpr size_t kRetryNum = (MWCAS_RETRY_THRESHOLD);
 

--- a/src/lock_free/mwcas_descriptor.cpp
+++ b/src/lock_free/mwcas_descriptor.cpp
@@ -69,21 +69,6 @@ constexpr uint64_t kCntMask = (kMwCASFlag - 1UL) ^ (kPosMask | kAddrMask);
 /// @brief A bitmask with only the "MwCAS FLAG" and "descriptor address" portions set to 1.
 constexpr uint64_t kDescMask = kMwCASFlag | kAddrMask;
 
-/// @brief The begin bit position of versions.
-constexpr uint64_t kVersionShift = kValueBitNum;
-
-/// @brief A unit value for incrementing versions.
-constexpr uint64_t kVersionUnit = 1UL << kVersionShift;
-
-/// @brief A bit mask for extracting actual values.
-constexpr uint64_t kValueMask = kVersionUnit - 1UL;
-
-/// @brief A bit mask for extracting versions and actual values.
-constexpr uint64_t kVerAndValMask = ~kMwCASFlag;
-
-/// @brief A bit mask for extracting versions.
-constexpr uint64_t kVersionMask = kVerAndValMask ^ kValueMask;
-
 /*##############################################################################
  * Local global variable
  *############################################################################*/
@@ -157,46 +142,38 @@ MwCASDescriptor::MwCASInternal(  //
     const size_t begin_pos)      //
     -> bool
 {
-  const auto desc_addr = std::bit_cast<uint64_t>(this) | kMwCASFlag;
+  const auto base_addr = std::bit_cast<uint64_t>(this) | kMwCASFlag;
   auto cur_stat = stat_.load(kSeqCst);
   if (cur_stat == kUndecided) {
     auto stat = kSucceeded;
     for (size_t i = begin_pos; i < target_cnt_; ++i) {
+      const auto desc_addr = base_addr | (i << kPosShift);
       auto &target = targets_[i];
       auto *addr = target.addr;
+      auto &old_val = target.old_val;
       auto word = addr->load(kSeqCst);
-      while (true) {
-        auto cur_old_val = target.old_val.load();
-        if (cur_old_val & kMwCASFlag) {
-          if (cur_old_val - word == kMwCASFlag
-                  && addr->compare_exchange_strong(word, desc_addr, kSeqCst, kSeqCst)
-              || (((word ^ desc_addr) & kDescMask) == 0)) {
-            break;
-          }
-          if ((word & kMwCASFlag) == 0) {
-            stat = kFailed;
-            goto out;
-          }
-          FollowIfNeeded(addr, word, kSeqCst);
-          continue;
-        }
-        if (target.old_val.compare_exchange_strong(cur_old_val, word | kMwCASFlag, kSeqCst, kSeqCst)
-            || cur_old_val == (addr->load(kSeqCst) | kMwCASFlag)) {
-          word = cur_old_val - kMwCASFlag;
-          if (word == target.old_val
-                  && addr->compare_exchange_strong(word, desc_addr, kSeqCst, kSeqCst)
-              || (((word ^ desc_addr) & kDescMask) == 0)) {
-            break;
-          }
-        }
-        if ((word & kMwCASFlag) == 0) {
-          stat = kFailed;
-          goto out;
-        }
-        FollowIfNeeded(addr, word, kSeqCst);
+
+      // retain the current version and try to embed the descriptor
+      auto expected = old_val.load(kSeqCst);
+      if (((expected & kMwCASFlag) == 0 && ((word ^ expected) & ~kVersionMask) == 0
+           && old_val.compare_exchange_strong(expected, word | kMwCASFlag, kSeqCst, kSeqCst)
+           && addr->compare_exchange_strong(word, desc_addr, kSeqCst, kSeqCst))) {
+        continue;
+      }
+
+      // this thread may be a follower, so use the retained word
+      if (word == expected && addr->compare_exchange_strong(word, desc_addr, kSeqCst, kSeqCst)) {
+        continue;
+      }
+
+      // check another thread has embedded the descriptor
+      if ((word & kDescMask) != base_addr) {
+        stat = kFailed;
+        break;
       }
     }
-  out:
+
+    // set a linearization point
     cur_stat = stat_.load(kSeqCst);
     if (cur_stat == kUndecided && stat_.compare_exchange_strong(cur_stat, stat, kSeqCst, kSeqCst)) {
       cur_stat = stat;
@@ -208,14 +185,14 @@ MwCASDescriptor::MwCASInternal(  //
   if (succeeded) {
     for (size_t i = 0; i < target_cnt_; ++i) {
       auto &target = targets_[i];
-      auto next_version = (target.old_val.load(kSeqCst) & kVersionMask) + kVersionUnit;
-      follow_cnt += Finalize(desc_addr, target,
-                             (target.new_val | next_version));  // new_valのバージョンを変更する
+      const auto ver = (target.old_val.load(kSeqCst) + kVersionUnit) & kVersionMask;
+      follow_cnt += Finalize(base_addr, target, (target.new_val | ver));
     }
   } else {
     for (size_t i = 0; i < target_cnt_; ++i) {
       auto &target = targets_[i];
-      follow_cnt += Finalize(desc_addr, target, target.old_val);
+      const auto val = (target.old_val.load(kSeqCst) + kVersionUnit) & kVerAndValMask;
+      follow_cnt += Finalize(base_addr, target, val);
     }
   }
 

--- a/src/lock_free/mwcas_descriptor.cpp
+++ b/src/lock_free/mwcas_descriptor.cpp
@@ -33,8 +33,8 @@
 #include "dbgroup/atomic/mwcas/utility.hpp"
 
 //                       Bit allocation of a word.
-// |     63     |       62-50       |      49-47     |        46-0       |
-// | MwCAS Flag | Reference Counter | Begin Position |Descriptor Address |
+// |     63     |       62-50       |      49-47     |         46-0       |
+// | MwCAS Flag | Reference Counter | Begin Position | Descriptor Address |
 
 //                   Bit allocation of an actual value.
 //          |           63           |  62-(N+1) |     N-0      |

--- a/src/lock_free/mwcas_descriptor.cpp
+++ b/src/lock_free/mwcas_descriptor.cpp
@@ -61,20 +61,28 @@ constexpr uint64_t kCntUnit = 1UL << kCntShift;
 constexpr uint64_t kAddrMask = (1UL << 47UL) - 1UL;
 
 /// @brief A bitmask with only the "begin position" portion set to 1.
-constexpr uint64_t kPosMask = (0b111UL << kPosShift);
+constexpr uint64_t kPosMask = (kCntUnit - 1UL) ^ kAddrMask;
 
 /// @brief A bitmask with only the "reference counter" portion set to 1.
-constexpr uint64_t kCntMask = (0b11111'11111111UL << kCntShift);
+constexpr uint64_t kCntMask = (kMwCASFlag - 1UL) ^ (kPosMask | kAddrMask);
 
 /// @brief A bitmask with only the "MwCAS FLAG" and "descriptor address" portions set to 1.
 constexpr uint64_t kDescMask = kMwCASFlag | kAddrMask;
 
-/// @brief 一時的においた定数．
-constexpr uint64_t kVersionShift = 50;
-/// @brief 一時的においた定数．
+/// @brief The begin bit position of versions.
+constexpr uint64_t kVersionShift = kValueBitNum;
+
+/// @brief A unit value for incrementing versions.
 constexpr uint64_t kVersionUnit = 1UL << kVersionShift;
-/// @brief 一時的においた定数．
-constexpr uint64_t kVersionMask = ((1UL << (62UL - kVersionShift)) - 1UL) << kVersionShift;
+
+/// @brief A bit mask for extracting actual values.
+constexpr uint64_t kValueMask = kVersionUnit - 1UL;
+
+/// @brief A bit mask for extracting versions and actual values.
+constexpr uint64_t kVerAndValMask = ~kMwCASFlag;
+
+/// @brief A bit mask for extracting versions.
+constexpr uint64_t kVersionMask = kVerAndValMask ^ kValueMask;
 
 /*##############################################################################
  * Local global variable


### PR DESCRIPTION
とりあえず実装を修正しました．詳細は差分を見てほしいですが，まずそうな箇所は概ね以下のとおりです．

- undo時にバージョン値が加算されていなかった．
- Read時に値を取り出すためのマスクをかけていなかった．
- **記述子埋込み時に現在のpositionを埋め込んでいなかった**．
    - これは自分が前のPRで出した実装からそうだったかも…．カウンタが正常に働いていなかったのはたぶんこれが原因です．
- minor: バージョンマスクが誤っていた．

で，これらを修正するついでに，MwCAS内での追従をしないように変更しました（つまり，MwCAS内で再帰的に他のMwCASの支援は行わない）．これはコードを簡略化させるためというのもありますが，MwCAS内で下手に追従するよりも早く諦めてReadから再試行した方が性能が出るというのが主です．なお，他のMwCASの追従処理はRead関数内で行うので，MwCAS全体として見ればlock-free性は保たれます（MwCAS実行前には対象領域のReadが必ず入るので）．