### PR TITLE
10/4 LFMwCASをエポックベースGCで実装

### DIFF
--- a/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
+++ b/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
@@ -100,18 +100,18 @@ class alignas(kCacheLineSize) MwCASDescriptor
    *##########################################################################*/
 
   /**
-   * @brief Start garbage collection for LFMwCAS descriptors.
+   * @brief Start garbage collection for this descriptors.
    *
    * @param gc_interval Interval for GC in microseconds.
    * @param gc_thread_num The number of worker threads to release garbages.
-   * @note This function must be called before performing LFMwCAS-based MwCAS.
+   * @note This function must be called before performing MwCAS.
    */
   static void StartGC(  //
       size_t gc_interval = ::dbgroup::memory::kDefaultGCTime,
       size_t gc_thread_num = ::dbgroup::memory::kDefaultGCThreadNum);
 
   /**
-   * @brief Stop garbage collection for LFMwCAS descriptors.
+   * @brief Stop garbage collection for this descriptors.
    *
    */
   static void StopGC();
@@ -123,7 +123,7 @@ class alignas(kCacheLineSize) MwCASDescriptor
       -> ::dbgroup::thread::EpochGuard;
 
   /**
-   * @return A new MwCAS descriptor for the LFMwCAS algorithm.
+   * @return A new descriptor for the MwCAS algorithm.
    * @note You must explicitly delete the given descriptor if you do not call
    * the MwCAS function.
    */
@@ -297,7 +297,7 @@ class alignas(kCacheLineSize) MwCASDescriptor
    * Internal member variables
    *##########################################################################*/
 
-  /// @brief The status of this LFMwCAS descriptor.
+  /// @brief The status of this descriptor.
   std::atomic<Status> stat_{kUndecided};
 
   /// @brief The number of registered MwCAS targets.

--- a/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
+++ b/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
@@ -289,7 +289,7 @@ class alignas(kCacheLineSize) MwCASDescriptor
       uint64_t desc_addr,   //
       MwCASTarget &target,  //
       uint64_t desired)     //
-      -> uint64_t;
+      -> bool;
 
   /*############################################################################
    * Internal member variables

--- a/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
+++ b/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
@@ -241,11 +241,10 @@ class alignas(kCacheLineSize) MwCASDescriptor
    * @param desired A desired value to be embedded.
    * @return The number of followers.
    */
-  auto Finalize(            //
+  void Finalize(            //
       uint64_t desc_addr,   //
       MwCASTarget &target,  //
-      uint64_t desired)     //
-      -> uint32_t;
+      uint64_t desired);
 
   /*############################################################################
    * Internal member variables
@@ -253,9 +252,6 @@ class alignas(kCacheLineSize) MwCASDescriptor
 
   /// @brief The status of this CASN descriptor.
   std::atomic<Status> stat_{kUndecided};
-
-  /// @brief The total number of threads that have completed referencing.
-  std::atomic_uint32_t exit_cnt_{};
 
   /// @brief The number of registered MwCAS targets.
   size_t target_cnt_{};

--- a/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
+++ b/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
@@ -287,7 +287,6 @@ class alignas(kCacheLineSize) MwCASDescriptor
    * @param desc_addr The address of this descriptor with the flag.
    * @param target A target MwCAS information.
    * @param desired A desired value to be embedded.
-   * @return The number of followers.
    */
   void Finalize(            //
       uint64_t desc_addr,   //

--- a/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
+++ b/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
@@ -276,7 +276,7 @@ class alignas(kCacheLineSize) MwCASDescriptor
    */
   auto MwCASInternal(        //
       size_t begin_pos = 0)  //
-      -> bool;
+      -> std::pair<bool, bool>;
 
   /**
    * @brief Swap an embedded descriptor into a desired value.
@@ -288,11 +288,8 @@ class alignas(kCacheLineSize) MwCASDescriptor
   auto Finalize(            //
       uint64_t desc_addr,   //
       MwCASTarget &target,  //
-      uint64_t desired)  //
-    -> uint64_t;
-      uint64_t desc_addr,   //
-      MwCASTarget &target,  //
-      uint64_t desired);
+      uint64_t desired)     //
+      -> uint64_t;
 
   /*############################################################################
    * Internal member variables

--- a/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
+++ b/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
@@ -24,6 +24,12 @@
 #include <cstddef>
 #include <cstdint>
 
+// external libraries
+#include "dbgroup/lock/common.hpp"
+#include "dbgroup/memory/epoch_based_gc.hpp"
+#include "dbgroup/memory/utility.hpp"
+#include "dbgroup/thread/epoch_guard.hpp"
+
 // local sources
 #include "dbgroup/atomic/mwcas/utility.hpp"
 
@@ -36,6 +42,19 @@ namespace dbgroup::atomic::mwcas::lock_free
 class alignas(kCacheLineSize) MwCASDescriptor
 {
  public:
+  /*############################################################################
+   * GC settings
+   *##########################################################################*/
+
+  /// @brief Do not call destructors.
+  using T = void;
+
+  /// @brief Reuse allocated descriptors.
+  static constexpr bool kReusePages = true;
+
+  /// @brief The number of retained descriptors in each thread.
+  static constexpr size_t kMaxReusableDescriptors = 64;
+
   /*############################################################################
    * Public constructors and assignment operators
    *##########################################################################*/
@@ -81,7 +100,30 @@ class alignas(kCacheLineSize) MwCASDescriptor
    *##########################################################################*/
 
   /**
-   * @return A new MwCAS descriptor for the MwCAS algorithm.
+   * @brief Start garbage collection for LFMwCAS descriptors.
+   *
+   * @param gc_interval Interval for GC in microseconds.
+   * @param gc_thread_num The number of worker threads to release garbages.
+   * @note This function must be called before performing LFMwCAS-based MwCAS.
+   */
+  static void StartGC(  //
+      size_t gc_interval = ::dbgroup::memory::kDefaultGCTime,
+      size_t gc_thread_num = ::dbgroup::memory::kDefaultGCThreadNum);
+
+  /**
+   * @brief Stop garbage collection for LFMwCAS descriptors.
+   *
+   */
+  static void StopGC();
+
+  /**
+   * @return A guard instance for preventing GC.
+   */
+  static auto CreateEpochGuard()  //
+      -> ::dbgroup::thread::EpochGuard;
+
+  /**
+   * @return A new MwCAS descriptor for the LFMwCAS algorithm.
    * @note You must explicitly delete the given descriptor if you do not call
    * the MwCAS function.
    */
@@ -152,6 +194,12 @@ class alignas(kCacheLineSize) MwCASDescriptor
       -> bool;
 
  private:
+  /*############################################################################
+   * Type aliases
+   *##########################################################################*/
+
+  using EpochBasedGC = ::dbgroup::memory::EpochBasedGC<MwCASDescriptor>;
+
   /*############################################################################
    * Internal types
    *##########################################################################*/
@@ -250,7 +298,7 @@ class alignas(kCacheLineSize) MwCASDescriptor
    * Internal member variables
    *##########################################################################*/
 
-  /// @brief The status of this CASN descriptor.
+  /// @brief The status of this LFMwCAS descriptor.
   std::atomic<Status> stat_{kUndecided};
 
   /// @brief The number of registered MwCAS targets.
@@ -258,6 +306,9 @@ class alignas(kCacheLineSize) MwCASDescriptor
 
   /// @brief Target entries of MwCAS.
   std::array<MwCASTarget, kMwCASCapacity> targets_ = {};
+
+  /// @brief A garbage collector for expired descriptors.
+  static inline std::unique_ptr<EpochBasedGC> _gc{};  // NOLINT
 };
 
 }  // namespace dbgroup::atomic::mwcas::lock_free

--- a/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
+++ b/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
@@ -285,7 +285,7 @@ class alignas(kCacheLineSize) MwCASDescriptor
    * @param target A target MwCAS information.
    * @param desired A desired value to be embedded.
    */
-  void Finalize(            //
+  bool Finalize(            //
       uint64_t desc_addr,   //
       MwCASTarget &target,  //
       uint64_t desired);

--- a/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
+++ b/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
@@ -181,7 +181,7 @@ class alignas(kCacheLineSize) MwCASDescriptor
     static_assert(CanMwCAS<T>());
 
     new (&(targets_.at(target_cnt_++)))
-        MwCASTarget{static_cast<std::atomic_uint64_t *>(addr), old_val, new_val, 0, fence};
+        MwCASTarget{static_cast<std::atomic_uint64_t *>(addr), old_val, new_val, fence};
   }
 
   /**
@@ -227,9 +227,6 @@ class alignas(kCacheLineSize) MwCASDescriptor
 
     /// @brief An inserting value into a target field.
     uint64_t new_val;
-
-    /// @brief The number of followers that start from this address.
-    std::atomic_uint32_t cnt;
 
     /// @brief A fence to be inserted when embedding a new value.
     std::memory_order fence;

--- a/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
+++ b/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
@@ -285,7 +285,11 @@ class alignas(kCacheLineSize) MwCASDescriptor
    * @param target A target MwCAS information.
    * @param desired A desired value to be embedded.
    */
-  bool Finalize(            //
+  auto Finalize(            //
+      uint64_t desc_addr,   //
+      MwCASTarget &target,  //
+      uint64_t desired)  //
+    -> uint64_t;
       uint64_t desc_addr,   //
       MwCASTarget &target,  //
       uint64_t desired);

--- a/src/lock_free/mwcas_descriptor.cpp
+++ b/src/lock_free/mwcas_descriptor.cpp
@@ -107,6 +107,7 @@ MwCASDescriptor::GetDescriptor() -> MwCASDescriptor *
   auto *page = _gc->GetPageIfPossible<MwCASDescriptor>();
   auto *desc = (page == nullptr) ? new MwCASDescriptor{} : static_cast<MwCASDescriptor *>(page);
   desc->target_cnt_ = 0;
+  return desc;
 }
 
 auto

--- a/src/lock_free/mwcas_descriptor.cpp
+++ b/src/lock_free/mwcas_descriptor.cpp
@@ -214,13 +214,10 @@ MwCASDescriptor::Finalize(  //
     MwCASTarget &target,
     const uint64_t desired)  //
 {
-  while (true) {
-    auto expected = target.addr->load(kRelaxed);
-    if (((expected ^ desc_addr) & kDescMask)                        // already swapped, or
-        || target.addr->compare_exchange_strong(expected, desired,  // swap succeeds
-                                                kRelaxed, kRelaxed)) {
-      return;
-    }
+  auto expected = target.addr->load(kRelaxed);
+  while (((expected ^ desc_addr) & kDescMask) == 0
+         && !target.addr->compare_exchange_weak(expected, desired, kRelaxed, kRelaxed)) {
+    CPP_UTILITY_SPINLOCK_HINT
   }
 }
 

--- a/src/lock_free/mwcas_descriptor.cpp
+++ b/src/lock_free/mwcas_descriptor.cpp
@@ -24,6 +24,7 @@
 #include <cstdint>
 #include <memory>
 #include <thread>
+#include <utility>
 
 // external libraries
 #include "dbgroup/lock/common.hpp"
@@ -164,7 +165,7 @@ MwCASDescriptor::FollowIfNeeded(  //
 auto
 MwCASDescriptor::MwCASInternal(  //
     const size_t begin_pos)      //
-    -> bool
+    -> std::pair<bool, bool>
 {
   const auto base_addr = std::bit_cast<uint64_t>(this) | kMwCASFlag;
   auto cur_stat = stat_.load(kAcquire);  // set a memory fence for followers
@@ -205,6 +206,8 @@ MwCASDescriptor::MwCASInternal(  //
       cur_stat = stat;
     }
   }
+
+  const auto succeeded = (cur_stat == kSucceeded);
   uint64_t ref_cnt{};
   if (succeeded) {
     for (size_t i = 0; i < target_cnt_; ++i) {
@@ -220,14 +223,15 @@ MwCASDescriptor::MwCASInternal(  //
     }
   }
 
-  return {succeeded, ref_cnt > 0};
+  return std::pair{succeeded, ref_cnt > 0};
 }
 
-bool
+auto
 MwCASDescriptor::Finalize(  //
-    const uint64_t desc_addr,
-    MwCASTarget &target,
-    const uint64_t desired)  //
+    uint64_t desc_addr,     //
+    MwCASTarget &target,    //
+    uint64_t desired)       //
+    -> uint64_t
 {
   auto expected = target.addr->load(kRelaxed);
   while (((expected ^ desc_addr) & kDescMask) == 0

--- a/src/lock_free/mwcas_descriptor.cpp
+++ b/src/lock_free/mwcas_descriptor.cpp
@@ -106,7 +106,7 @@ MwCASDescriptor::GetDescriptor()  //
     -> MwCASDescriptor *
 {
   auto *page = _gc->GetPageIfPossible<MwCASDescriptor>();
-  auto *desc = (page == nullptr) ? new MwCASDescriptor{} : static_cast<MwCASDescriptor *>(page);
+  auto *desc = (page) ? static_cast<MwCASDescriptor *>(page) : new MwCASDescriptor{};
   desc->target_cnt_ = 0;
   return desc;
 }

--- a/src/lock_free/mwcas_descriptor.cpp
+++ b/src/lock_free/mwcas_descriptor.cpp
@@ -27,6 +27,7 @@
 
 // external libraries
 #include "dbgroup/lock/common.hpp"
+#include "dbgroup/memory/epoch_based_gc.hpp"
 #include "dbgroup/memory/utility.hpp"
 
 // local sources
@@ -72,20 +73,40 @@ constexpr uint64_t kDescMask = kMwCASFlag | kAddrMask;
 }  // namespace
 
 /*##############################################################################
+ * Static utilities
+ *############################################################################*/
+
+void
+MwCASDescriptor::StartGC(  //
+    const size_t gc_interval,
+    const size_t gc_thread_num)
+{
+  _gc = std::make_unique<EpochBasedGC>(gc_interval, gc_thread_num, kMaxReusableDescriptors);
+}
+
+void
+MwCASDescriptor::StopGC()
+{
+  _gc.reset();
+}
+
+auto
+MwCASDescriptor::CreateEpochGuard()  //
+    -> ::dbgroup::thread::EpochGuard
+{
+  return _gc->CreateEpochGuard();
+}
+
+/*##############################################################################
  * Public APIs
  *############################################################################*/
 
 auto
-MwCASDescriptor::GetDescriptor()  // TODO: fix later
-    -> MwCASDescriptor *
+MwCASDescriptor::GetDescriptor() -> MwCASDescriptor *
 {
-  auto *desc = _tls.release();
-  if (!desc) {
-    desc = ::dbgroup::memory::Allocate<MwCASDescriptor>();
-  }
+  auto *page = _gc->GetPageIfPossible<MwCASDescriptor>();
+  auto *desc = (page == nullptr) ? new MwCASDescriptor{} : static_cast<MwCASDescriptor *>(page);
   desc->target_cnt_ = 0;
-  desc->exit_cnt_.store(0, kRelaxed);
-  return desc;
 }
 
 auto

--- a/src/lock_free/mwcas_descriptor.cpp
+++ b/src/lock_free/mwcas_descriptor.cpp
@@ -236,8 +236,10 @@ MwCASDescriptor::Finalize(  //
   auto expected = target.addr->load(kRelaxed);
   while (true) {
     if (((expected ^ desc_addr) & kDescMask) != 0) return true;
-    if (target.addr->compare_exchange_weak(expected, desired, kRelaxed, kRelaxed))
+    if (target.addr->compare_exchange_weak(expected, desired, kRelaxed, kRelaxed)) {
       return (expected & kCntMask) != 0;
+    }
+    CPP_UTILITY_SPINLOCK_HINT
   }
 }
 

--- a/src/lock_free/mwcas_descriptor.cpp
+++ b/src/lock_free/mwcas_descriptor.cpp
@@ -140,13 +140,6 @@ MwCASDescriptor::FollowIfNeeded(  //
     // follow another MwCAS
     auto *another_desc = std::bit_cast<MwCASDescriptor *>(word & kAddrMask);
     const auto pos = (word & kPosMask) >> kPosShift;
-    auto &desc_cnt = another_desc->targets_[pos].cnt;
-    auto cur_cnt = desc_cnt.load(kRelaxed);
-    const auto cnt = static_cast<uint32_t>((incremented & kCntMask) >> kCntShift);
-    while (cur_cnt < cnt) {  // increment the descriptor's counter
-      if (desc_cnt.compare_exchange_weak(cur_cnt, cnt, kRelaxed, kRelaxed)) break;
-      CPP_UTILITY_SPINLOCK_HINT
-    }
     another_desc->MwCASInternal(pos + 1);
     word = addr->load(fence);
   }
@@ -223,18 +216,10 @@ MwCASDescriptor::Finalize(  //
 {
   while (true) {
     auto expected = target.addr->load(kRelaxed);
-    auto cur_cnt = target.cnt.load(kRelaxed);
-    const auto cnt = static_cast<uint32_t>((expected & kCntMask) >> kCntShift);
-    if (((expected ^ desc_addr) & kDescMask)                            // already swapped, or
-        || (cur_cnt == cnt                                              // counter is latest and
-            && target.addr->compare_exchange_strong(expected, desired,  // swap succeeds
-                                                    kRelaxed, kRelaxed))) {
+    if (((expected ^ desc_addr) & kDescMask)                        // already swapped, or
+        || target.addr->compare_exchange_strong(expected, desired,  // swap succeeds
+                                                kRelaxed, kRelaxed)) {
       return;
-    }
-    // the descriptor's counter should be updated
-    while (cur_cnt < cnt) {
-      if (target.cnt.compare_exchange_weak(cur_cnt, cnt, kRelaxed, kRelaxed)) break;
-      CPP_UTILITY_SPINLOCK_HINT
     }
   }
 }

--- a/src/lock_free/mwcas_descriptor.cpp
+++ b/src/lock_free/mwcas_descriptor.cpp
@@ -126,8 +126,10 @@ MwCASDescriptor::MwCAS()  //
     -> bool
 {
   stat_.store(kUndecided, kRelease);  // set a memory fence
-  const auto succeeded = MwCASInternal();
-  if (_tls.get() == nullptr) {
+  const auto [succeeded, referred] = MwCASInternal();
+  if (referred) {
+    _tls.reset(this);
+  } else {
     _gc->AddGarbage<MwCASDescriptor>(this);
   }
   return succeeded;

--- a/src/lock_free/mwcas_descriptor.cpp
+++ b/src/lock_free/mwcas_descriptor.cpp
@@ -129,9 +129,9 @@ MwCASDescriptor::MwCAS()  //
   stat_.store(kUndecided, kRelease);  // set a memory fence
   const auto [succeeded, referred] = MwCASInternal();
   if (referred) {
-    _tls.reset(this);
-  } else {
     _gc->AddGarbage<MwCASDescriptor>(this);
+  } else {
+    _tls.reset(this);
   }
   return succeeded;
 }

--- a/src/lock_free/mwcas_descriptor.cpp
+++ b/src/lock_free/mwcas_descriptor.cpp
@@ -234,7 +234,7 @@ MwCASDescriptor::Finalize(  //
          && !target.addr->compare_exchange_weak(expected, desired, kRelaxed, kRelaxed)) {
     CPP_UTILITY_SPINLOCK_HINT
   }
-  return (expected & kCntMask) == 0;
+  return expected & kCntMask;
 }
 
 }  // namespace dbgroup::atomic::mwcas::lock_free

--- a/src/lock_free/mwcas_descriptor.cpp
+++ b/src/lock_free/mwcas_descriptor.cpp
@@ -208,22 +208,22 @@ MwCASDescriptor::MwCASInternal(  //
   }
 
   const auto succeeded = (cur_stat == kSucceeded);
-  uint64_t ref_cnt{};
+  bool referred = false;
   if (succeeded) {
     for (size_t i = 0; i < target_cnt_; ++i) {
       auto &target = targets_[i];
       const auto ver = (target.old_val.load(kRelaxed) + kVersionUnit) & kVersionMask;
-      ref_cnt += Finalize(base_addr, target, (target.new_val | ver));
+      referred = Finalize(base_addr, target, (target.new_val | ver)) || referred;
     }
   } else {
     for (size_t i = 0; i < target_cnt_; ++i) {
       auto &target = targets_[i];
       const auto val = (target.old_val.load(kRelaxed) + kVersionUnit) & kVerAndValMask;
-      ref_cnt += Finalize(base_addr, target, val);
+      referred = Finalize(base_addr, target, val) || referred;
     }
   }
 
-  return std::pair{succeeded, ref_cnt > 0};
+  return std::pair{succeeded, referred};
 }
 
 auto
@@ -231,14 +231,14 @@ MwCASDescriptor::Finalize(  //
     uint64_t desc_addr,     //
     MwCASTarget &target,    //
     uint64_t desired)       //
-    -> uint64_t
+    -> bool
 {
   auto expected = target.addr->load(kRelaxed);
-  while (((expected ^ desc_addr) & kDescMask) == 0
-         && !target.addr->compare_exchange_weak(expected, desired, kRelaxed, kRelaxed)) {
-    CPP_UTILITY_SPINLOCK_HINT
+  while (true) {
+    if (((expected ^ desc_addr) & kDescMask) != 0) return true;
+    if (target.addr->compare_exchange_weak(expected, desired, kRelaxed, kRelaxed))
+      return (expected & kCntMask) != 0;
   }
-  return expected & kCntMask;
 }
 
 }  // namespace dbgroup::atomic::mwcas::lock_free

--- a/src/lock_free/mwcas_descriptor.cpp
+++ b/src/lock_free/mwcas_descriptor.cpp
@@ -70,6 +70,13 @@ constexpr uint64_t kCntMask = (kMwCASFlag - 1UL) ^ (kPosMask | kAddrMask);
 /// @brief A bitmask with only the "MwCAS FLAG" and "descriptor address" portions set to 1.
 constexpr uint64_t kDescMask = kMwCASFlag | kAddrMask;
 
+/*##############################################################################
+ * Local global variable
+ *############################################################################*/
+
+/// @brief A thread local descriptor for reuse.
+thread_local std::unique_ptr<MwCASDescriptor> _tls = nullptr;  // NOLINT
+
 }  // namespace
 
 /*##############################################################################
@@ -105,8 +112,11 @@ auto
 MwCASDescriptor::GetDescriptor()  //
     -> MwCASDescriptor *
 {
-  auto *page = _gc->GetPageIfPossible<MwCASDescriptor>();
-  auto *desc = (page) ? static_cast<MwCASDescriptor *>(page) : new MwCASDescriptor{};
+  auto *desc = _tls.release();
+  if (!desc) {
+    auto *page = _gc->GetPageIfPossible<MwCASDescriptor>();
+    desc = (page) ? static_cast<MwCASDescriptor *>(page) : new MwCASDescriptor{};
+  }
   desc->target_cnt_ = 0;
   return desc;
 }
@@ -117,7 +127,9 @@ MwCASDescriptor::MwCAS()  //
 {
   stat_.store(kUndecided, kRelease);  // set a memory fence
   const auto succeeded = MwCASInternal();
-  _gc->AddGarbage<MwCASDescriptor>(this);
+  if (_tls.get() == nullptr) {
+    _gc->AddGarbage<MwCASDescriptor>(this);
+  }
   return succeeded;
 }
 
@@ -193,18 +205,23 @@ MwCASDescriptor::MwCASInternal(  //
   }
 
   const auto succeeded = (cur_stat == kSucceeded);
+  auto all_cnts_zero = true;
   if (succeeded) {
     for (size_t i = 0; i < target_cnt_; ++i) {
       auto &target = targets_[i];
       const auto ver = (target.old_val.load(kRelaxed) + kVersionUnit) & kVersionMask;
-      Finalize(base_addr, target, (target.new_val | ver));
+      all_cnts_zero &= Finalize(base_addr, target, (target.new_val | ver));
     }
   } else {
     for (size_t i = 0; i < target_cnt_; ++i) {
       auto &target = targets_[i];
       const auto val = (target.old_val.load(kRelaxed) + kVersionUnit) & kVerAndValMask;
-      Finalize(base_addr, target, val);
+      all_cnts_zero &= Finalize(base_addr, target, val);
     }
+  }
+
+  if (all_cnts_zero) {
+    _tls.reset(this);
   }
 
   return succeeded;

--- a/src/lock_free/mwcas_descriptor.cpp
+++ b/src/lock_free/mwcas_descriptor.cpp
@@ -205,28 +205,22 @@ MwCASDescriptor::MwCASInternal(  //
       cur_stat = stat;
     }
   }
-
-  const auto succeeded = (cur_stat == kSucceeded);
-  auto all_cnts_zero = true;
+  uint64_t ref_cnt{};
   if (succeeded) {
     for (size_t i = 0; i < target_cnt_; ++i) {
       auto &target = targets_[i];
       const auto ver = (target.old_val.load(kRelaxed) + kVersionUnit) & kVersionMask;
-      all_cnts_zero &= Finalize(base_addr, target, (target.new_val | ver));
+      ref_cnt += Finalize(base_addr, target, (target.new_val | ver));
     }
   } else {
     for (size_t i = 0; i < target_cnt_; ++i) {
       auto &target = targets_[i];
       const auto val = (target.old_val.load(kRelaxed) + kVersionUnit) & kVerAndValMask;
-      all_cnts_zero &= Finalize(base_addr, target, val);
+      ref_cnt += Finalize(base_addr, target, val);
     }
   }
 
-  if (all_cnts_zero) {
-    _tls.reset(this);
-  }
-
-  return succeeded;
+  return {succeeded, ref_cnt > 0};
 }
 
 bool

--- a/src/lock_free/mwcas_descriptor.cpp
+++ b/src/lock_free/mwcas_descriptor.cpp
@@ -210,7 +210,7 @@ MwCASDescriptor::MwCASInternal(  //
   return succeeded;
 }
 
-void
+bool
 MwCASDescriptor::Finalize(  //
     const uint64_t desc_addr,
     MwCASTarget &target,
@@ -221,6 +221,7 @@ MwCASDescriptor::Finalize(  //
          && !target.addr->compare_exchange_weak(expected, desired, kRelaxed, kRelaxed)) {
     CPP_UTILITY_SPINLOCK_HINT
   }
+  return (expected & kCntMask) == 0;
 }
 
 }  // namespace dbgroup::atomic::mwcas::lock_free

--- a/src/lock_free/mwcas_descriptor.cpp
+++ b/src/lock_free/mwcas_descriptor.cpp
@@ -102,7 +102,8 @@ MwCASDescriptor::CreateEpochGuard()  //
  *############################################################################*/
 
 auto
-MwCASDescriptor::GetDescriptor() -> MwCASDescriptor *
+MwCASDescriptor::GetDescriptor()  //
+    -> MwCASDescriptor *
 {
   auto *page = _gc->GetPageIfPossible<MwCASDescriptor>();
   auto *desc = (page == nullptr) ? new MwCASDescriptor{} : static_cast<MwCASDescriptor *>(page);

--- a/src/lock_free/mwcas_descriptor.cpp
+++ b/src/lock_free/mwcas_descriptor.cpp
@@ -116,7 +116,9 @@ MwCASDescriptor::MwCAS()  //
     -> bool
 {
   stat_.store(kUndecided, kRelease);  // set a memory fence
-  return MwCASInternal();
+  const auto succeeded = MwCASInternal();
+  _gc->AddGarbage<MwCASDescriptor>(this);
+  return succeeded;
 }
 
 /*##############################################################################

--- a/src/lock_free/mwcas_descriptor.cpp
+++ b/src/lock_free/mwcas_descriptor.cpp
@@ -69,13 +69,6 @@ constexpr uint64_t kCntMask = (kMwCASFlag - 1UL) ^ (kPosMask | kAddrMask);
 /// @brief A bitmask with only the "MwCAS FLAG" and "descriptor address" portions set to 1.
 constexpr uint64_t kDescMask = kMwCASFlag | kAddrMask;
 
-/*##############################################################################
- * Local global variable
- *############################################################################*/
-
-/// @brief A thread local descriptor for reuse.
-thread_local std::unique_ptr<MwCASDescriptor> _tls = nullptr;  // NOLINT
-
 }  // namespace
 
 /*##############################################################################
@@ -83,7 +76,7 @@ thread_local std::unique_ptr<MwCASDescriptor> _tls = nullptr;  // NOLINT
  *############################################################################*/
 
 auto
-MwCASDescriptor::GetDescriptor()  //
+MwCASDescriptor::GetDescriptor()  // TODO: fix later
     -> MwCASDescriptor *
 {
   auto *desc = _tls.release();
@@ -182,34 +175,28 @@ MwCASDescriptor::MwCASInternal(  //
   }
 
   const auto succeeded = (cur_stat == kSucceeded);
-  auto follow_cnt = 0U;
   if (succeeded) {
     for (size_t i = 0; i < target_cnt_; ++i) {
       auto &target = targets_[i];
       const auto ver = (target.old_val.load(kRelaxed) + kVersionUnit) & kVersionMask;
-      follow_cnt += Finalize(base_addr, target, (target.new_val | ver));
+      Finalize(base_addr, target, (target.new_val | ver));
     }
   } else {
     for (size_t i = 0; i < target_cnt_; ++i) {
       auto &target = targets_[i];
       const auto val = (target.old_val.load(kRelaxed) + kVersionUnit) & kVerAndValMask;
-      follow_cnt += Finalize(base_addr, target, val);
+      Finalize(base_addr, target, val);
     }
-  }
-
-  if (follow_cnt == 0 || exit_cnt_.fetch_add(1, kRelaxed) == follow_cnt) {
-    _tls.reset(this);
   }
 
   return succeeded;
 }
 
-auto
+void
 MwCASDescriptor::Finalize(  //
     const uint64_t desc_addr,
     MwCASTarget &target,
     const uint64_t desired)  //
-    -> uint32_t
 {
   while (true) {
     auto expected = target.addr->load(kRelaxed);
@@ -219,7 +206,7 @@ MwCASDescriptor::Finalize(  //
         || (cur_cnt == cnt                                              // counter is latest and
             && target.addr->compare_exchange_strong(expected, desired,  // swap succeeds
                                                     kRelaxed, kRelaxed))) {
-      return cur_cnt;
+      return;
     }
     // the descriptor's counter should be updated
     while (cur_cnt < cnt) {

--- a/test/mwcas_descriptors_test.cpp
+++ b/test/mwcas_descriptors_test.cpp
@@ -98,7 +98,7 @@ class MwCASDescriptorFixture : public ::testing::Test
   TearDown() override
   {
     if constexpr (std::is_same_v<MwCASDesc, AOPT> || std::is_same_v<MwCASDesc, CASN>
-                  || std::is_same_v<MwCASDesc, CASN>) {
+                  || std::is_same_v<MwCASDesc, LFMwCAS>) {
       MwCASDesc::StopGC();
     }
   }

--- a/test/mwcas_descriptors_test.cpp
+++ b/test/mwcas_descriptors_test.cpp
@@ -88,7 +88,8 @@ class MwCASDescriptorFixture : public ::testing::Test
       target_fields_[i] = 0UL;
     }
 
-    if constexpr (std::is_same_v<MwCASDesc, AOPT> || std::is_same_v<MwCASDesc, CASN>) {
+    if constexpr (std::is_same_v<MwCASDesc, AOPT> || std::is_same_v<MwCASDesc, CASN>
+                  || std::is_same_v<MwCASDesc, LFMwCAS>) {
       MwCASDesc::StartGC();
     }
   }
@@ -96,7 +97,8 @@ class MwCASDescriptorFixture : public ::testing::Test
   void
   TearDown() override
   {
-    if constexpr (std::is_same_v<MwCASDesc, AOPT> || std::is_same_v<MwCASDesc, CASN>) {
+    if constexpr (std::is_same_v<MwCASDesc, AOPT> || std::is_same_v<MwCASDesc, CASN>
+                  || std::is_same_v<MwCASDesc, CASN>) {
       MwCASDesc::StopGC();
     }
   }

--- a/test/mwcas_descriptors_test.cpp
+++ b/test/mwcas_descriptors_test.cpp
@@ -129,18 +129,7 @@ class MwCASDescriptorFixture : public ::testing::Test
   MwCAS(  //
       const MwCASTargets &targets)
   {
-    if constexpr (std::is_same_v<MwCASDesc, LFMwCAS>) {
-      while (true) {
-        auto *desc = MwCASDesc::GetDescriptor();
-        for (auto idx : targets) {
-          auto *addr = &(target_fields_[idx]);
-          const auto cur_val = MwCASDesc::template Read<Target>(addr, kRelaxed);
-          const auto new_val = cur_val + 1;
-          desc->AddMwCASTarget(addr, cur_val, new_val, kRelaxed);
-        }
-        if (desc->MwCAS()) return;
-      }
-    } else if constexpr (std::is_same_v<MwCASDesc, DLFMwCAS>) {
+    if constexpr (std::is_same_v<MwCASDesc, DLFMwCAS>) {
       while (true) {
         MwCASDesc desc{};
         for (auto idx : targets) {

--- a/test/mwcas_descriptors_test.cpp
+++ b/test/mwcas_descriptors_test.cpp
@@ -32,6 +32,7 @@
 #include <vector>
 
 // external libraries
+#include "dbgroup/random/zipf.hpp"
 #include "gtest/gtest.h"
 
 // local sources
@@ -56,6 +57,8 @@ constexpr size_t kExecNum = 1e6;
 
 constexpr size_t kTargetFieldNum = kMwCASCapacity * kTestThreadNum;
 
+constexpr double kSkewParameter = 0.0;
+
 /*##############################################################################
  * Fixture definitions
  *############################################################################*/
@@ -70,6 +73,7 @@ class MwCASDescriptorFixture : public ::testing::Test
 
   using Target = uint64_t;
   using MwCASTargets = std::vector<size_t>;
+  using Zipf = ::dbgroup::random::ApproxZipfDistribution<size_t>;
 
   /*############################################################################
    * Internal constants
@@ -199,7 +203,7 @@ class MwCASDescriptorFixture : public ::testing::Test
         MwCASTargets targets{};
         targets.reserve(kMwCASCapacity);
         while (targets.size() < kMwCASCapacity) {
-          size_t idx = id_dist_(rand_engine);
+          size_t idx = zipf_dist_(rand_engine);
           const auto iter = std::find(targets.begin(), targets.end(), idx);
           if (iter == targets.end()) {
             targets.emplace_back(idx);
@@ -226,7 +230,7 @@ class MwCASDescriptorFixture : public ::testing::Test
 
   Target target_fields_[kTargetFieldNum]{};
 
-  std::uniform_int_distribution<size_t> id_dist_{0, kTargetFieldNum - 1};
+  Zipf zipf_dist_{0, kTargetFieldNum - 1, kSkewParameter};
 
   std::shared_mutex main_lock_{};
 


### PR DESCRIPTION
CASNを参考に，epoch-based GC を LFMwCAS に追加したので，レビューしていただきたいです．

参照カウンタのうち，参入カウンタはバックオフに必要なため削除せず，退却カウンタ(exit_cnt)のみ削除しました．
TLSも不要なため削除しました．

最低限CTestは通ることを確認しています．ご確認よろしくお願いいたします．