### PR TITLE
WrapCounterとStopWatchの導入

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ if(NOT TARGET dbgroup::${PROJECT_NAME})
     "${CMAKE_CURRENT_SOURCE_DIR}/src/lock_free/mwcas_descriptor.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/lock_free/casn_descriptor.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/lock_free/aopt_descriptor.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/stop_watch.cpp"
   )
   add_library(dbgroup::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
   target_compile_features(${PROJECT_NAME} PUBLIC

--- a/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
+++ b/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
@@ -35,6 +35,7 @@
 
 // local sources
 #include "dbgroup/atomic/mwcas/utility.hpp"
+#include "dbgroup/benchmark/stop_watch.hpp"
 
 namespace dbgroup::atomic::mwcas::lock_free
 {
@@ -105,6 +106,13 @@ class alignas(kCacheLineSize) MwCASDescriptor
   static auto CalcMaxVersionWrapCountSum()  //
       -> uint64_t;
 
+  [[nodiscard]] static auto
+  GetStopWatch()  //
+      -> dbgroup::benchmark::StopWatch &
+  {
+    return sw;
+  }
+
   /*############################################################################
    * Public APIs for managing memory
    *##########################################################################*/
@@ -166,7 +174,9 @@ class alignas(kCacheLineSize) MwCASDescriptor
     auto *target_addr = static_cast<std::atomic_uint64_t *>(addr);
     auto word = target_addr->load(fence);
     while (word & kMwCASFlag) {
+      sw.Start();
       FollowIfNeeded(target_addr, word, fence);
+      sw.Stop();
     }
     return std::pair{std::bit_cast<T>(word & kValueMask), std::bit_cast<T>(word)};
   }
@@ -321,6 +331,9 @@ class alignas(kCacheLineSize) MwCASDescriptor
 
   /// @brief Target entries of MwCAS.
   std::array<MwCASTarget, kMwCASCapacity> targets_ = {};
+
+  /// @brief A stopwatch for measuring FollowIfNeeded execution time.
+  static inline thread_local dbgroup::benchmark::StopWatch sw{};
 
   /// @brief A garbage collector for expired descriptors.
   static inline std::unique_ptr<EpochBasedGC> _gc{};  // NOLINT

--- a/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
+++ b/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
@@ -24,6 +24,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <utility>
+#include <vector>
 
 // external libraries
 #include "dbgroup/lock/common.hpp"
@@ -97,10 +98,10 @@ class alignas(kCacheLineSize) MwCASDescriptor
   }
 
   /**
-   * @brief Get the version wrap count for the current thread.
-   * @return The number of times the version counter wrapped in this thread.
+   * @brief Get the TOTAL version wrap count across ALL threads.
+   * @return The sum of version wrap counts.
    */
-  static auto GetTlsVersionWrapCount()  //
+  static auto GetVersionWrapCountSum()  //
       -> uint64_t;
 
   /*############################################################################
@@ -240,6 +241,19 @@ class alignas(kCacheLineSize) MwCASDescriptor
     std::memory_order fence;
   };
 
+  /**
+   * @brief A counter structure aligned to cache lines to prevent false sharing.
+   */
+  struct alignas(kCacheLineSize) VersionCounter {
+    std::atomic_uint64_t count{0};
+
+    VersionCounter() = default;
+
+    VersionCounter(const VersionCounter &other) : count(other.count.load(std::memory_order_relaxed))
+    {
+    }
+  };
+
   /*############################################################################
    * Internal constants
    *##########################################################################*/
@@ -314,6 +328,10 @@ class alignas(kCacheLineSize) MwCASDescriptor
 
   /// @brief A garbage collector for expired descriptors.
   static inline std::unique_ptr<EpochBasedGC> _gc{};  // NOLINT
+
+  /// @brief Global version wrap counters for each thread.
+  /// defined inline (C++17 feature) to avoid multiple definition errors.
+  static inline std::vector<VersionCounter> version_wrap_counts_;
 };
 
 }  // namespace dbgroup::atomic::mwcas::lock_free

--- a/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
+++ b/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
@@ -96,6 +96,13 @@ class alignas(kCacheLineSize) MwCASDescriptor
     return target_cnt_;
   }
 
+  /**
+   * @brief Get the version wrap count for the current thread.
+   * @return The number of times the version counter wrapped in this thread.
+   */
+  static auto GetTlsVersionWrapCount()  //
+      -> uint64_t;
+
   /*############################################################################
    * Public APIs for managing memory
    *##########################################################################*/

--- a/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
+++ b/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
@@ -106,12 +106,7 @@ class alignas(kCacheLineSize) MwCASDescriptor
   static auto CalcMaxVersionWrapCountSum()  //
       -> uint64_t;
 
-  [[nodiscard]] static auto
-  GetStopWatch()  //
-      -> dbgroup::benchmark::StopWatch &
-  {
-    return sw;
-  }
+  [[nodiscard]] static auto GetStopWatch() -> dbgroup::benchmark::StopWatch;
 
   /*############################################################################
    * Public APIs for managing memory
@@ -174,9 +169,10 @@ class alignas(kCacheLineSize) MwCASDescriptor
     auto *target_addr = static_cast<std::atomic_uint64_t *>(addr);
     auto word = target_addr->load(fence);
     while (word & kMwCASFlag) {
-      sw.Start();
+      const auto thread_id = ::dbgroup::thread::IDManager::GetThreadID();
+      sw_vec_[thread_id].Start();
       FollowIfNeeded(target_addr, word, fence);
-      sw.Stop();
+      sw_vec_[thread_id].Stop();
     }
     return std::pair{std::bit_cast<T>(word & kValueMask), std::bit_cast<T>(word)};
   }
@@ -333,7 +329,7 @@ class alignas(kCacheLineSize) MwCASDescriptor
   std::array<MwCASTarget, kMwCASCapacity> targets_ = {};
 
   /// @brief A stopwatch for measuring FollowIfNeeded execution time.
-  static inline thread_local dbgroup::benchmark::StopWatch sw{};
+  static inline std::vector<dbgroup::benchmark::StopWatch> sw_vec_{};
 
   /// @brief A garbage collector for expired descriptors.
   static inline std::unique_ptr<EpochBasedGC> _gc{};  // NOLINT

--- a/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
+++ b/include/dbgroup/atomic/mwcas/lock_free/mwcas_descriptor.hpp
@@ -23,6 +23,7 @@
 #include <bit>
 #include <cstddef>
 #include <cstdint>
+#include <map>
 #include <utility>
 #include <vector>
 
@@ -101,7 +102,7 @@ class alignas(kCacheLineSize) MwCASDescriptor
    * @brief Get the TOTAL version wrap count across ALL threads.
    * @return The sum of version wrap counts.
    */
-  static auto GetVersionWrapCountSum()  //
+  static auto CalcMaxVersionWrapCountSum()  //
       -> uint64_t;
 
   /*############################################################################
@@ -242,16 +243,11 @@ class alignas(kCacheLineSize) MwCASDescriptor
   };
 
   /**
-   * @brief A counter structure aligned to cache lines to prevent false sharing.
+   * @brief A shard of the version wrap map, aligned to cache lines.
+   * Each thread owns one shard to record wrap counts without contention.
    */
-  struct alignas(kCacheLineSize) VersionCounter {
-    std::atomic_uint64_t count{0};
-
-    VersionCounter() = default;
-
-    VersionCounter(const VersionCounter &other) : count(other.count.load(std::memory_order_relaxed))
-    {
-    }
+  struct alignas(kCacheLineSize) VersionWrapMapShard {
+    std::map<uint64_t, uint64_t> counts;
   };
 
   /*############################################################################
@@ -329,9 +325,8 @@ class alignas(kCacheLineSize) MwCASDescriptor
   /// @brief A garbage collector for expired descriptors.
   static inline std::unique_ptr<EpochBasedGC> _gc{};  // NOLINT
 
-  /// @brief Global version wrap counters for each thread.
-  /// defined inline (C++17 feature) to avoid multiple definition errors.
-  static inline std::vector<VersionCounter> version_wrap_counts_;
+  /// @brief Per-thread map shards to store wrap counts.
+  static inline std::vector<VersionWrapMapShard> wrap_count_shards_;
 };
 
 }  // namespace dbgroup::atomic::mwcas::lock_free

--- a/include/dbgroup/benchmark/stop_watch.hpp
+++ b/include/dbgroup/benchmark/stop_watch.hpp
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2026 Database Group, Nagoya University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef DBGROUP_BENCHMARK_STOP_WATCH_HPP_
+#define DBGROUP_BENCHMARK_STOP_WATCH_HPP_
+
+// C++ standard libraries
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+
+namespace dbgroup::benchmark
+{
+/**
+ * @brief A class for computing approximated quantile.
+ *
+ * This implementation is based on DDSketch [1] but is simplified. This uses the
+ * fixed number of bins and ignores the performance of quantile queries.
+ *
+ * [1] Charles Masson et al., "DDSketch: A fast and fully-mergeable quantile
+ * sketch with relative-error guarantees," PVLDB, Vol. 12, No. 12, pp. 2195-2205,
+ * 2019.
+ */
+class StopWatch
+{
+  /*##########################################################################*
+   * Type aliases
+   *##########################################################################*/
+
+  using Clock_t = ::std::chrono::high_resolution_clock;
+
+ public:
+  /*##########################################################################*
+   * Public constructors and assignment operators
+   *##########################################################################*/
+
+  constexpr StopWatch() noexcept = default;
+
+  constexpr StopWatch(const StopWatch &) noexcept = default;
+  constexpr StopWatch(StopWatch &&) noexcept = default;
+
+  constexpr auto operator=(const StopWatch &obj) noexcept -> StopWatch & = default;
+  constexpr auto operator=(StopWatch &&) noexcept -> StopWatch & = default;
+
+  /*##########################################################################*
+   * Public destructors
+   *##########################################################################*/
+
+  ~StopWatch() = default;
+
+  /*##########################################################################*
+   * Public operators
+   *##########################################################################*/
+
+  /**
+   * @retval true if this stop watch has measurements.
+   * @retval false otherwise.
+   */
+  [[nodiscard]]
+  constexpr explicit
+  operator bool() const noexcept
+  {
+    return exec_num_ > 0;
+  }
+
+  /**
+   * @brief Merge a given sketch into this.
+   *
+   * @param rhs A sketch to be merged.
+   */
+  constexpr void
+  operator+=(  //
+      const StopWatch &rhs) noexcept
+  {
+    exec_num_ += rhs.exec_num_;
+    exec_time_ += rhs.exec_time_;
+    min_ = std::min(min_, rhs.min_);
+    max_ = std::max(max_, rhs.max_);
+    for (uint32_t i = 0; i < kBinNum; ++i) {
+      bins_[i] += rhs.bins_[i];
+    }
+  }
+
+  /*##########################################################################*
+   * Public APIs
+   *##########################################################################*/
+
+  /**
+   * @brief Start this stopwatch to measure time duration.
+   *
+   * @note If calling this function without the corresponding `Stop` function,
+   * the beginning time of a measurement will be overwritten.
+   */
+  void Start() noexcept;
+
+  /**
+   * @brief Stop this stopwatch.
+   *
+   * @param cnt The number of executed operations for computing throughput.
+   * @note The `Start` function must precede this every time. If calling this
+   * function multiple times without the corresponding` Start`, the logged
+   * execution time will be doubly counted.
+   */
+  void Stop(  //
+      size_t cnt = 1);
+
+  /**
+   * @param q A target quantile value.
+   * @return The latency of given quantile.
+   */
+  [[nodiscard]]
+  auto Quantile(       //
+      double q) const  //
+      -> size_t;
+
+  /**
+   * @return The total execution time in nanoseconds.
+   */
+  [[nodiscard]]
+  constexpr auto
+  GetExecTime() const noexcept  //
+      -> size_t
+  {
+    return exec_time_;
+  }
+
+  /**
+   * @return The total number of executed operations.
+   */
+  [[nodiscard]]
+  constexpr auto
+  GetExecNum() const noexcept  //
+      -> size_t
+  {
+    return exec_num_;
+  }
+
+ private:
+  /*##########################################################################*
+   * Internal constants
+   *##########################################################################*/
+
+  /// @brief The number of bins.
+  static constexpr uint32_t kBinNum = 2048;
+
+  /*##########################################################################*
+   * Internal member variables
+   *##########################################################################*/
+
+  /// @brief A starting timestamp.
+  Clock_t::time_point st_{};
+
+  /// @brief The number of executed operations.
+  uint32_t exec_num_{};
+
+  /// @brief Total execution time [ns].
+  size_t exec_time_{};
+
+  /// @brief The minimum latency [ns].
+  size_t min_{~0UL};
+
+  /// @brief The maximum latency [ns].
+  size_t max_{};
+
+  /// @brief Execution time for each operation [ns].
+  std::array<uint32_t, kBinNum> bins_{};
+};
+
+}  // namespace dbgroup::benchmark
+
+#endif  // DBGROUP_BENCHMARK_STOP_WATCH_HPP_

--- a/src/lock_free/mwcas_descriptor.cpp
+++ b/src/lock_free/mwcas_descriptor.cpp
@@ -78,6 +78,9 @@ constexpr uint64_t kDescMask = kMwCASFlag | kAddrMask;
 /// @brief A thread local descriptor for reuse.
 thread_local std::unique_ptr<MwCASDescriptor> _tls = nullptr;  // NOLINT
 
+/// @brief A thread local counter for version wraps.
+thread_local uint64_t _tls_version_wrap_count = 0;  // NOLINT
+
 }  // namespace
 
 /*##############################################################################
@@ -108,6 +111,13 @@ MwCASDescriptor::CreateEpochGuard()  //
 /*##############################################################################
  * Public APIs
  *############################################################################*/
+
+auto
+MwCASDescriptor::GetTlsVersionWrapCount()  //
+    -> uint64_t
+{
+  return _tls_version_wrap_count;
+}
 
 auto
 MwCASDescriptor::GetDescriptor()  //
@@ -230,6 +240,9 @@ MwCASDescriptor::Finalize(  //
   while (true) {
     if (((expected ^ desc_addr) & kDescMask) != 0) return true;
     if (target.addr->compare_exchange_weak(expected, desired, kRelaxed, kRelaxed)) {
+      if ((desired & kVersionMask) == 0) {
+        _tls_version_wrap_count++;
+      }
       return (expected & kCntMask) != 0;
     }
     CPP_UTILITY_SPINLOCK_HINT

--- a/src/lock_free/mwcas_descriptor.cpp
+++ b/src/lock_free/mwcas_descriptor.cpp
@@ -34,6 +34,7 @@
 
 // local sources
 #include "dbgroup/atomic/mwcas/utility.hpp"
+#include "dbgroup/benchmark/stop_watch.hpp"
 
 //                       Bit allocation of a word.
 // |     63     |       62-50       |      49-47     |         46-0       |
@@ -93,8 +94,10 @@ MwCASDescriptor::StartGC(  //
   if (wrap_count_shards_.empty()) {
 #ifdef DBGROUP_MAX_THREAD_NUM
     wrap_count_shards_.resize(DBGROUP_MAX_THREAD_NUM);
+    sw_vec_.resize(DBGROUP_MAX_THREAD_NUM);
 #else
     wrap_count_shards_.resize(112);
+    sw_vec_.resize(112);
 #endif
   }
   _gc = std::make_unique<EpochBasedGC>(gc_interval, gc_thread_num, kMaxReusableDescriptors);
@@ -137,6 +140,17 @@ MwCASDescriptor::CalcMaxVersionWrapCountSum()  //
   }
 
   return max_count;
+}
+
+auto
+MwCASDescriptor::GetStopWatch() -> dbgroup::benchmark::StopWatch
+{
+  dbgroup::benchmark::StopWatch merged_sw;
+
+  for (const auto &sw : sw_vec_) {
+    merged_sw += sw;
+  }
+  return merged_sw;
 }
 
 auto

--- a/src/lock_free/mwcas_descriptor.cpp
+++ b/src/lock_free/mwcas_descriptor.cpp
@@ -30,6 +30,7 @@
 #include "dbgroup/lock/common.hpp"
 #include "dbgroup/memory/epoch_based_gc.hpp"
 #include "dbgroup/memory/utility.hpp"
+#include "dbgroup/thread/id_manager.hpp"
 
 // local sources
 #include "dbgroup/atomic/mwcas/utility.hpp"
@@ -78,9 +79,6 @@ constexpr uint64_t kDescMask = kMwCASFlag | kAddrMask;
 /// @brief A thread local descriptor for reuse.
 thread_local std::unique_ptr<MwCASDescriptor> _tls = nullptr;  // NOLINT
 
-/// @brief A thread local counter for version wraps.
-thread_local uint64_t _tls_version_wrap_count = 0;  // NOLINT
-
 }  // namespace
 
 /*##############################################################################
@@ -92,6 +90,9 @@ MwCASDescriptor::StartGC(  //
     const size_t gc_interval,
     const size_t gc_thread_num)
 {
+  if (version_wrap_counts_.empty()) {
+    version_wrap_counts_.resize(gc_thread_num);
+  }
   _gc = std::make_unique<EpochBasedGC>(gc_interval, gc_thread_num, kMaxReusableDescriptors);
 }
 
@@ -113,10 +114,14 @@ MwCASDescriptor::CreateEpochGuard()  //
  *############################################################################*/
 
 auto
-MwCASDescriptor::GetTlsVersionWrapCount()  //
+MwCASDescriptor::GetVersionWrapCountSum()  //
     -> uint64_t
 {
-  return _tls_version_wrap_count;
+  uint64_t total_count = 0;
+  for (const auto &counter : version_wrap_counts_) {
+    total_count += counter.count.load(std::memory_order_relaxed);
+  }
+  return total_count;
 }
 
 auto
@@ -241,7 +246,8 @@ MwCASDescriptor::Finalize(  //
     if (((expected ^ desc_addr) & kDescMask) != 0) return true;
     if (target.addr->compare_exchange_weak(expected, desired, kRelaxed, kRelaxed)) {
       if ((desired & kVersionMask) == 0) {
-        _tls_version_wrap_count++;
+        const auto thread_id = ::dbgroup::thread::IDManager::GetThreadID();
+        version_wrap_counts_[thread_id].count.fetch_add(1, std::memory_order_relaxed);
       }
       return (expected & kCntMask) != 0;
     }

--- a/src/lock_free/mwcas_descriptor.cpp
+++ b/src/lock_free/mwcas_descriptor.cpp
@@ -91,7 +91,11 @@ MwCASDescriptor::StartGC(  //
     const size_t gc_thread_num)
 {
   if (version_wrap_counts_.empty()) {
-    version_wrap_counts_.resize(gc_thread_num);
+#ifdef DBGROUP_MAX_THREAD_NUM
+    version_wrap_counts_.resize(DBGROUP_MAX_THREAD_NUM);
+#else
+    version_wrap_counts_.resize(112);
+#endif
   }
   _gc = std::make_unique<EpochBasedGC>(gc_interval, gc_thread_num, kMaxReusableDescriptors);
 }

--- a/src/lock_free/mwcas_descriptor.cpp
+++ b/src/lock_free/mwcas_descriptor.cpp
@@ -90,11 +90,11 @@ MwCASDescriptor::StartGC(  //
     const size_t gc_interval,
     const size_t gc_thread_num)
 {
-  if (version_wrap_counts_.empty()) {
+  if (wrap_count_shards_.empty()) {
 #ifdef DBGROUP_MAX_THREAD_NUM
-    version_wrap_counts_.resize(DBGROUP_MAX_THREAD_NUM);
+    wrap_count_shards_.resize(DBGROUP_MAX_THREAD_NUM);
 #else
-    version_wrap_counts_.resize(112);
+    wrap_count_shards_.resize(112);
 #endif
   }
   _gc = std::make_unique<EpochBasedGC>(gc_interval, gc_thread_num, kMaxReusableDescriptors);
@@ -118,14 +118,25 @@ MwCASDescriptor::CreateEpochGuard()  //
  *############################################################################*/
 
 auto
-MwCASDescriptor::GetVersionWrapCountSum()  //
+MwCASDescriptor::CalcMaxVersionWrapCountSum()  //
     -> uint64_t
 {
-  uint64_t total_count = 0;
-  for (const auto &counter : version_wrap_counts_) {
-    total_count += counter.count.load(std::memory_order_relaxed);
+  std::map<uint64_t, uint64_t> merged_map;
+
+  for (const auto &shard : wrap_count_shards_) {
+    for (const auto &[addr, count] : shard.counts) {
+      merged_map[addr] += count;
+    }
   }
-  return total_count;
+
+  uint64_t max_count = 0;
+  for (const auto &[addr, total_count] : merged_map) {
+    if (total_count > max_count) {
+      max_count = total_count;
+    }
+  }
+
+  return max_count;
 }
 
 auto
@@ -251,7 +262,7 @@ MwCASDescriptor::Finalize(  //
     if (target.addr->compare_exchange_weak(expected, desired, kRelaxed, kRelaxed)) {
       if ((desired & kVersionMask) == 0) {
         const auto thread_id = ::dbgroup::thread::IDManager::GetThreadID();
-        version_wrap_counts_[thread_id].count.fetch_add(1, std::memory_order_relaxed);
+        wrap_count_shards_[thread_id].counts[std::bit_cast<uint64_t>(target.addr)]++;
       }
       return (expected & kCntMask) != 0;
     }

--- a/src/stop_watch.cpp
+++ b/src/stop_watch.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 Database Group, Nagoya University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// the corresponding header
+#include "dbgroup/benchmark/stop_watch.hpp"
+
+// C++ standard libraries
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+
+namespace dbgroup::benchmark
+{
+namespace
+{
+/*############################################################################*
+ * Local constants
+ *############################################################################*/
+
+/// @brief A desired relative error.
+constexpr double kAlpha = 0.01;
+
+/// @brief The base value for approximation.
+constexpr double kGamma = (1.0 + kAlpha) / (1.0 - kAlpha);
+
+/// @brief The denominator for the logarithm change of base.
+const double denom = std::log(kGamma);
+
+}  // namespace
+
+/*############################################################################*
+ * Public APIs
+ *############################################################################*/
+
+void
+StopWatch::Start() noexcept
+{
+  std::atomic_thread_fence(std::memory_order_acq_rel);
+  st_ = Clock_t::now();
+  std::atomic_thread_fence(std::memory_order_acq_rel);
+}
+
+void
+StopWatch::Stop(  //
+    const size_t cnt)
+{
+  using NS = std::chrono::nanoseconds;
+
+  std::atomic_thread_fence(std::memory_order_acq_rel);
+  const auto et = Clock_t::now();
+  std::atomic_thread_fence(std::memory_order_acq_rel);
+
+  const size_t lat = std::chrono::duration_cast<NS>(et - st_).count();
+  exec_num_ += cnt;
+  exec_time_ += lat;
+  if (lat < min_) [[unlikely]] {
+    min_ = lat;
+  }
+  if (lat > 0) [[likely]] {
+    if (lat > max_) [[unlikely]] {
+      max_ = lat;
+    }
+    const uint32_t pos = std::ceil(std::log(lat) / denom);
+    ++bins_[pos];
+  } else {
+    ++bins_[0];
+  }
+}
+
+auto
+StopWatch::Quantile(       //
+    const double q) const  //
+    -> size_t
+{
+  if (q == 0) return min_;
+  if (q >= 1.0) return max_;
+
+  const auto bound = static_cast<uint32_t>(q * static_cast<double>(exec_num_ - 1));
+  auto cnt = bins_[0];
+  auto i = 0U;
+  while (i < kBinNum - 1 && cnt <= bound) {
+    cnt += bins_[++i];
+  }
+  return static_cast<size_t>(2 * std::pow(kGamma, i) / (kGamma + 1));
+}
+
+}  // namespace dbgroup::benchmark


### PR DESCRIPTION
バージョンカウンタのオーバーラップのカウンタと，FollowIfNeededのレイテンシを測定するStopWatchを導入しました．

それぞれ計測後，メインスレッドからCalcMaxVersionWrapCountSum()とGetStopWatch()を実行することで，統計情報を取得できるようになっています．

ご確認よろしくお願いいたします．